### PR TITLE
Drop support of Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 # Config file for automatic testing at travis-ci.org
-sudo: false
+dist: xenial
 language: python
+cache: pip
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
   - pip install -U tox-travis

--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@ Control Leica microscopes with python
 
 ## Installation
 
+- **The latest version of leicacam requires Python 3.5+**
+- If you need to keep using Python 2.7, pin your version of leicacam to 0.3.0.
+
 Install using `pip`:
 
 ```bash
-pip install leicacam
-```
-Install version using asyncio. This requires Python 3.5+:
-```bash
-pip3 install leicacam[asyncio]
+pip3 install leicacam
 ```
 
 ## Example

--- a/leicacam/cam.py
+++ b/leicacam/cam.py
@@ -1,6 +1,4 @@
 """Provide an interface to the CAM server."""
-from __future__ import print_function
-
 import os
 import functools
 import logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+async_timeout==2.0.1
 pydebug==1.0.3

--- a/requirements_asyncio.txt
+++ b/requirements_asyncio.txt
@@ -1,3 +1,0 @@
-async_timeout==2.0.1
-asynctest==0.12.2
-pytest-asyncio==0.9.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
--r requirements_asyncio.txt
 -r requirements_pypi.txt
 -r requirements_test.txt
 -r docs/requirements.txt

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,8 @@
+asynctest==0.12.2
 flake8==3.6.0
 mock==2.0.0
 pydocstyle==3.0.0
 pylint==1.9.3
 pytest==4.0.1
+pytest-asyncio==0.9.0
 pytest-cov==2.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pydocstyle]
+convention = numpy

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,11 @@ setup(
     package_dir={'leicacam': 'leicacam'},
     package_data={'leicacam': ['VERSION']},
     include_package_data=True,
+    python_requires='>=3.5',
     install_requires=[
-        'pydebug'
+        'async_timeout',
+        'pydebug',
     ],
-    extras_require={
-        'asyncio':  ['async_timeout'],
-    },
     license='MIT',
     zip_safe=False,
     keywords='leicacam',
@@ -38,11 +37,9 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = py2.7, asyncio, py3.6, lint
+envlist = py35, py36, py37, lint
 skip_missing_interpreters = True
 
 [travis]
 python =
-  2.7: py27
-  3.5: asyncio, lint
-  3.6: asyncio
+  3.5: py35, lint
 
 [testenv]
 setenv =
@@ -15,24 +13,12 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_test.txt
 commands =
-    pytest --basetemp={envtmpdir} {posargs} test/test_cam.py
-
-[testenv:asyncio]
-basepython = python3
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/leicacam
-deps =
-    -r{toxinidir}/requirements.txt
-    -r{toxinidir}/requirements_asyncio.txt
-    -r{toxinidir}/requirements_test.txt
-commands =
     pytest --basetemp={envtmpdir} {posargs}
 
 [testenv:lint]
 basepython = python3
 deps =
     -r{toxinidir}/requirements.txt
-    -r{toxinidir}/requirements_asyncio.txt
     -r{toxinidir}/requirements_test.txt
 ignore_errors = True
 commands =


### PR DESCRIPTION
* Python 2.7 is end of life in 2020-01-01.

**Changes**
* Require Python 3.5+.
* Update tox and travis environments.
* Update readme.