### PR TITLE
Remove mock dependency

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,5 @@
 asynctest==0.13.0
 flake8==3.7.8
-mock==3.0.5
 pydocstyle==4.0.1
 pylint==2.3.1
 pytest==5.1.2

--- a/test/test_cam.py
+++ b/test/test_cam.py
@@ -1,9 +1,9 @@
 """Tests for cam module."""
 import socket
 from collections import OrderedDict
+from unittest.mock import MagicMock, patch
 
 import pytest
-from mock import MagicMock, patch
 
 from leicacam.cam import CAM, bytes_as_dict, tuples_as_bytes, tuples_as_dict
 


### PR DESCRIPTION
* `mock` is part of standard library from Python 3.3.