### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.8"
+  version: "3.9"
   install:
     - requirements: docs/requirements.txt
     - path: .

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Control Leica microscopes with python
 
 ## Installation
 
-- **The latest version of leicacam requires Python 3.8+**
+- **The latest version of leicacam requires Python 3.9+**
 - If you need to keep using Python 2.7, pin your version of leicacam to 0.3.0.
 
 Install using `pip`:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Set up package."""
+
 from pathlib import Path
 
 from setuptools import find_packages, setup
@@ -22,7 +23,7 @@ setup(
     url="https://github.com/MartinHjelmare/leicacam",
     packages=find_packages(exclude=["test", "test.*"]),
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=["async_timeout", "pydebug"],
     license="MIT",
     zip_safe=False,
@@ -33,7 +34,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py38, py39, py310, lint, docs
+envlist = py39, py310, lint, docs
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.8: py38, docs, lint
-  3.9: py39
+  3.9: py39, docs, lint
   3.10: py310
 
 [testenv]


### PR DESCRIPTION
- Python 3.8 is end of life since October 2024.