### PR TITLE
fix: remove pydebug dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 ]
 dependencies = [
   "async-timeout",
-  "pydebug",
 ]
 urls."Bug Tracker" = "https://github.com/MartinHjelmare/leicacam/issues"
 urls.Changelog = "https://github.com/MartinHjelmare/leicacam/blob/main/CHANGELOG.md"

--- a/src/leicacam/cam.py
+++ b/src/leicacam/cam.py
@@ -7,12 +7,10 @@ from collections.abc import Callable
 import functools
 import logging
 import os
-import platform
 import socket
+import sys
 from time import sleep, time
 from typing import Any, cast
-
-import pydebug
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,20 +32,11 @@ def logger[**P, R](function: Callable[P, R]) -> Callable[P, R]:
 
 
 # debug with `DEBUG=leicacam python script.py`
-if platform.system() == "Windows":
-    # monkeypatch
-    @logger
-    def debug(msg: bytes | str) -> None:
-        """Debug on Windows."""
-        try:
-            dbg = os.environ["DEBUG"]
-            if dbg in ("leicacam", "*"):
-                print("leicacam " + str(msg))
-        except KeyError:
-            pass
-
-else:
-    debug = logger(pydebug.debug("leicacam"))
+@logger
+def debug(msg: bytes | str) -> None:
+    """Print debug message to stderr when DEBUG enables leicacam."""
+    if os.environ.get("DEBUG") in ("leicacam", "*"):
+        print("leicacam " + str(msg), file=sys.stderr)
 
 
 class BaseCAM:

--- a/uv.lock
+++ b/uv.lock
@@ -543,7 +543,6 @@ version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "async-timeout" },
-    { name = "pydebug" },
 ]
 
 [package.dev-dependencies]
@@ -567,10 +566,7 @@ docs = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "async-timeout" },
-    { name = "pydebug" },
-]
+requires-dist = [{ name = "async-timeout" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -878,12 +874,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
     { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
 ]
-
-[[package]]
-name = "pydebug"
-version = "1.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5b/7a/161dfb5bb88e8ee49851e43e1ab0fe5c71a56285cf4bbb82b08035f45f59/pydebug-1.0.3.tar.gz", hash = "sha256:d81094bf93943614acaad413ee0b4fda77d721b81a90856668a41a0ff0e401c1", size = 4330, upload-time = "2013-10-13T14:01:55.978Z" }
 
 [[package]]
 name = "pygments"


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/leicacam/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Replace the pydebug-based debug function with a stdlib equivalent. The Windows platform-specific branch already used pure Python; unify both branches into one implementation using os.environ and sys.stderr. This drops the abandoned pydebug package (2013) from the dependency tree.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/leicacam/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
